### PR TITLE
986064: Resolve Failures in GitHub Repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,18 @@ Make sure that you have the latest versions of NodeJS and Visual Studio Code in 
 
 ### How to run this application?
 
-To run this application, you need to clone the `getting-started-with-the-react-carousel-component` repository and then open it in Visual Studio Code. Now, simply install all the necessary react packages into your current project using the `npm install` command and run your project using the `npm start` command.
+To run this application, follow the steps below:
+1. Clone the `getting-started-with-the-react-carousel-component` repository
+
+2. Open the Project
+Navigate to the cloned folder and open it in Visual Studio Code or your preferred code editor.
+
+3. Install Dependencies
+Run the following command in the terminal to install all necessary React packages:
+`npm install`
+
+4. Start the Application
+Once the installation is complete, start the development server using:
+`npm start`
+
+This will compile the project and launch it in your default browser at http://localhost:3000.


### PR DESCRIPTION
### Bug description
[986064](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/986064/): Resolve Failures in GitHub Repositories

### Root cause,
The repository readme must have a minimum length of 1000 characters, whereas the current readme length is less than 1000 characters

### Reason for not identifying earlier
Find how it was missed in our earlier testing and development by analysing the below checklist. This will help prevent similar mistakes in the future. 

 - [x] Guidelines/documents are not followed

    - Specification document

 - [ ] Guidelines/documents are not given

    - Common guidelines / Core team guideline
    - Specification document
    - Requirement document


### Reason:

I have resolved by add the content in Readme description.

### Output screenshots:

NA

### Action taken:

I have resolved by add the content in Readme description.

### Related areas:

NA

### Is it a breaking issue?

No

### Solution description

I have resolved by add the content in Readme description.

### Areas affected and ensured

NA

### Additional checklist
This may vary for different teams or products. Check with your scrum masters.

  - Did you run the automation against your fix? Yes
  - Is there any API name change? No
  - Is there any existing behavior change of other features due to this code change? No
  - Does your new code introduce new warnings or binding errors? No
  - Does your code pass all FxCop and StyleCop rules? NA
  - Did you record this case in the unit test or UI test? NA
  - 